### PR TITLE
Update tutorials for new CLI and variable names

### DIFF
--- a/tutorials/admin/getting-started/installation.md
+++ b/tutorials/admin/getting-started/installation.md
@@ -1,12 +1,12 @@
 # Installation
 
-This tutorial describes how to install a Marble node on a server. 
+This tutorial describes how to install a Marble node on a server.
 
 ## Prerequisites
 
 ### Docker
 
-Marble is deployed as a [Docker](https://www.docker.com/) application using the 
+Marble is deployed as a [Docker](https://www.docker.com/) application using the
 [compose](https://docs.docker.com/compose/) tool to manage various services that make up the application.
 
 To install Docker on Unix/Linux either install [Docker Engine](https://docs.docker.com/engine/install/) (recommended) or
@@ -14,8 +14,8 @@ To install Docker on Unix/Linux either install [Docker Engine](https://docs.dock
 Docker Desktop.
 
 ```{warning}
-We highly recommend installing Marble on a Unix/Linux machine, specifically Ubuntu 18.04+ if possible. All code is 
-developed and tested on Ubuntu, and we cannot guarantee that the software will behave as expected on other operating 
+We highly recommend installing Marble on a Unix/Linux machine, specifically Ubuntu 18.04+ if possible. All code is
+developed and tested on Ubuntu, and we cannot guarantee that the software will behave as expected on other operating
 systems.
 ```
 
@@ -51,7 +51,7 @@ discounted domain name with your purchase of a cloud based virtual machine.
 
 A static public IP address is required so that the domain name server will know where to forward internet traffic to.
 
-If you are hosting your Marble node in a cloud based environment, follow the instructions from your cloud service 
+If you are hosting your Marble node in a cloud based environment, follow the instructions from your cloud service
 provider on how to forward internet traffic to your virtual machine.
 
 If you are installing Marble on premises at an institution, contact the institution's IT department to ask how to
@@ -59,7 +59,7 @@ acquire your public static IP for the purposes of setting up a web application.
 
 ```{note}
 Most residential internet service plans only provide *dynamic* public IP addresses, which are not suitable for hosting
-a web application. You may be able to request a static IP address from your internet service provider (ISP) for a small 
+a web application. You may be able to request a static IP address from your internet service provider (ISP) for a small
 fee depending on your ISP and/or geographical region.
 ```
 
@@ -76,7 +76,7 @@ We recommend using a tool like [certbot](https://certbot.eff.org/) to get and ma
 managing them yourself.
 
 ```{note}
-If using [certbot](https://certbot.eff.org/), note that the Marble stack uses 
+If using [certbot](https://certbot.eff.org/), note that the Marble stack uses
 [nginx](https://docs.nginx.com/nginx/admin-guide/web-server/reverse-proxy/) as a reverse proxy.
 
 Certbot also requires that the website be already running and that ports 80 and 443 are open.
@@ -85,7 +85,7 @@ To deploy the stack and start the website see the instructions [here](deploy-mar
 
 ### Git
 
-The Marble source code is hosted on [GitHub](https://github.com) and a `git` client is highly recommended to download 
+The Marble source code is hosted on [GitHub](https://github.com) and a `git` client is highly recommended to download
 and update the source code.
 
 Your server may already have `git` installed. To check run the following command from the command line:
@@ -110,24 +110,81 @@ Marble can be deployed using the [birdhouse-deploy](https://github.com/bird-hous
 git clone https://github.com/bird-house/birdhouse-deploy.git
 ```
 
-This will download the [Birdhouse](https://github.com/bird-house/birdhouse-deploy/) source code to the current 
+This will download the [Birdhouse](https://github.com/bird-house/birdhouse-deploy/) source code to the current
 directory.
 
 The most up-to-date version of the source code is on the `master` branch. We recommend always using this branch.
 
+(birdhouse-cli)=
+### Command Line Interface (CLI)
+
+The command line interface (CLI) for interacting with the Birdhouse software can be found at `bin/birdhouse`.
+
+This CLI provides utilities to manage the Birdhouse software like a docker compose project, display build information,
+and manage configuration settings.
+
+For a full description of the CLI usage run it with the `--help` flag:
+
+```shell
+cd birdhouse-deploy
+./bin/birdhouse --help
+```
+
+For convenience we recommend adding the ``birdhouse-deploy/bin/`` directory to your ``PATH``:
+
+```shell
+export PATH="$(readlink -f ./bin):$PATH"
+
+# Now instead of running (from the root directory of this project):
+
+./bin/birdhouse --help
+
+# you can run (from anywhere):
+
+birdhouse --help
+```
+
+```{note}
+All tutorials in this section will assume that you have added the `birdhouse` executable to your `PATH`.
+This means that all examples will be written as:
+
+:::shell
+birdhouse ...
+:::
+
+instead of
+:::shell
+cd birdhouse-deploy
+./bin/birdhouse ...
+:::
+```
+
+To ensure that your PATH variable always includes this directory in login shells:
+
+```shell
+echo "export PATH=$(readlink -f ./bin)"':$PATH' >> ~/.profile
+```
+
+```{warning}
+It is no longer recommended to call scripts other than `bin/birdhouse` directly. In previous versions, we recommended
+interacting with the platform by calling scripts (like `birdhouse-compose.sh` or `read-configs.include.sh`)
+directly. These scripts have been left in place for backwards compatibility **for now** but may be moved or modified
+in some future version. We recommend updating any external scripts to use the CLI as soon as possible.
+```
+
 ### Create the local environment file
 
-Your Marble deployment can be configured and customized by editing a local environment file. To create this file:
+Your Marble deployment can be configured and customized by editing a local environment file. By default this file is located at `birdhouse/env.local`. To create this file:
 
 ```shell
 cd birdhouse-deploy/birdhouse
 touch env.local
 ```
 
-An (incomplete) example of this file named `env.local.example` can be used as a starting point. 
+An (incomplete) example of this file named `env.local.example` can be used as a starting point.
 
 ```{warning}
-`env.local.example` contains a lot of default examples that *must* be updated. For this reason, we do not recommend 
+`env.local.example` contains a lot of default examples that *must* be updated. For this reason, we do not recommend
 just copying `env.local.example` to `env.local`
 ```
 
@@ -145,42 +202,39 @@ file which will instruct you:
 (deploy-marble)=
 ## Deploying Marble
 
-The Marble stack can be started, stopped and inspected using the `pavics-compose.sh` script which takes the same 
-arguments as the [`docker compose`](https://docs.docker.com/compose/) commands.
+The Marble stack can be started, stopped and inspected using the `compose` command to the [birdhouse CLI](birdhouse-cli) which takes the same arguments as the [`docker compose`](https://docs.docker.com/compose/) commands.
 
-The `pavics-compose.sh` script will read the `env.local` configuration file, create a `docker compose` deployment file
-based on this configuration and then execute any subcommands provided to the `pavics-compose.sh` file as subcommands to 
-`docker compose` based on that file. 
+This command will read the `env.local` configuration file, create a `docker compose` deployment file
+based on this configuration and then execute any subcommands provided as if they were subcommands
+to `docker compose` based on that file.
 
 For example, to start the Marble stack:
 
 ```shell
-cd birdhouse-deploy/birdhouse
-./pavics-compose.sh up --detach
+birdhouse compose up --detach
 ```
 
 This will call the [`docker compose up --detach`](https://docs.docker.com/engine/reference/commandline/compose_up/)
-which will start up all the docker containers required to run the Marble stack.
+command which will start up all the docker containers required to run the Marble stack.
 
 Similarly, to stop and bring down the stack use:
 
 ```shell
-cd birdhouse-deploy/birdhouse
-./pavics-compose.sh down
+birdhouse compose down
 ```
 
 which will call `docker compose down` internally.
 
 ## Check that everything is working
 
-Once you have started the Marble stack with the `./pavics-compose.sh up --detach` command, check that everything is
+Once you have started the Marble stack with the `birdhouse compose up --detach` command, check that everything is
 working properly by opening your webpage in a browser:
 
 - Navigate to the domain name [that you set up](fqdn)
 - Ensure that the page loads as expected
   - Note that the page that loads should be the one set by the `PROXY_ROOT_LOCATION` variable in `env.local`
 - Ensure that the connection is secure (uses the https protocol with a valid certificate)
-  - If not: ensure that your SSL certificate is up-to-date and that `SSL_CERTIFICATE` variable in `env.local` is
+  - If not: ensure that your SSL certificate is up-to-date and that `BIRDHOUSE_SSL_CERTIFICATE` variable in `env.local` is
     pointing to the correct file (see the birdhouse documentation for details)
 
 ## Next Steps
@@ -207,7 +261,7 @@ And finally you'll want to start adding users to your node:
 ## Example installation steps
 
 Here is an example of how to install Marble on a server running Ubuntu 20.04, using <span>mymarble</span>.com as a FQDN,
-and where we get an SSL certificate using [certbot](https://certbot.eff.org/). We assume that 
+and where we get an SSL certificate using [certbot](https://certbot.eff.org/). We assume that
 [docker](https://www.docker.com/) and [git](https://git-scm.com/) are already installed:
 
 ```shell
@@ -216,18 +270,18 @@ git clone https://github.com/bird-house/birdhouse-deploy.git
 cd birdhouse-deploy/birdhouse
 
 # Configure env.local
-echo "export PAVICS_FQDN=mymarble.com" > env.local
-echo "export DOC_URL='https://marbleclimate.com'" >> env.local
+echo "export BIRDHOUSE_FQDN=mymarble.com" > env.local
+echo "export BIRDHOUSE_DOC_URL='https://marbleclimate.com'" >> env.local
 echo "export MAGPIE_SECRET=$(openssl rand -hex 32)" >> env.local
 echo "export MAGPIE_ADMIN_USERNAME=admin" >> env.local
 echo "export MAGPIE_ADMIN_PASSWORD=$(openssl rand -base64 12)" >> env.local
-echo "export SUPPORT_EMAIL=info@mymarble.com" >> env.local
-echo "export POSTGRES_PAVICS_USERNAME=postgres-pavics" >> env.local
-echo "export POSTGRES_PAVICS_PASSWORD=$(openssl rand -base64 12)" >> env.local
+echo "export BIRDHOUSE_SUPPORT_EMAIL=info@mymarble.com" >> env.local
+echo "export BIRDHOUSE_POSTGRES_USERNAME=postgres-birdhouse" >> env.local
+echo "export BIRDHOUSE_POSTGRES_PASSWORD=$(openssl rand -base64 12)" >> env.local
 echo "export POSTGRES_MAGPIE_USERNAME=postgres-magpie" >> env.local
 echo "export POSTGRES_MAGPIE_PASSWORD=$(openssl rand -base64 12)" >> env.local
 
-echo "export EXTRA_CONF_DIRS='...'" >> env.local # fill in the ... with the additional components you want to add
+echo "export BIRDHOUSE_EXTRA_CONF_DIRS='...'" >> env.local # fill in the ... with the additional components you want to add
 
 # Get an SSL certificate with certbot
 sudo snap install --classic certbot
@@ -236,8 +290,8 @@ sudo certbot certonly --apache --domain mymarble.com # and follow any additional
 
 # Create a file that contains a combination of the fullchain.pem and the privkey.pem files
 sudo cat /etc/letsencrypt/live/mymarble.com/fullchain.pem /etc/letsencrypt/live/mymarble.com/privkey.pem > cert.pem
-echo "export SSL_CERTIFICATE=$(pwd)/cert.pem" >> env.local
+echo "export BIRDHOUSE_SSL_CERTIFICATE=$(pwd)/cert.pem" >> env.local
 
 # Start the server
-./pavics-compose.sh up -d
+birdhouse compose up -d
 ```

--- a/tutorials/admin/getting-started/updating.md
+++ b/tutorials/admin/getting-started/updating.md
@@ -1,14 +1,14 @@
 # Updating the Software
 
 Occasionally Marble will release updates to its software. These updates may include bugfixes, feature updates, and
-security patches. 
+security patches.
 
 It is important to keep your Marble node up to date. This is especially important if your node is part of the Marble
 network so that we can ensure that all nodes in the network are secure and provide predictably similar features.
 
 ### Updating to the latest version
 
-Before you start, have a look at the [CHANGES.md](https://github.com/bird-house/birdhouse-deploy/blob/master/CHANGES.md) 
+Before you start, have a look at the [CHANGES.md](https://github.com/bird-house/birdhouse-deploy/blob/master/CHANGES.md)
 file in the [Birdhouse repository](https://github.com/bird-house/birdhouse-deploy) to see what changes have been made in
 the most recent versions.
 
@@ -24,11 +24,10 @@ First navigate to the directory that contains the `birdhouse-deploy` source code
 cd birdhouse-deploy
 ```
 
-Then use the `pavics-compose.sh` script to stop the stack momentarily while you update the code:
+Then use the [Birdhouse CLI](birdhouse-cli) to stop the stack momentarily while you update the code:
 
 ```shell
-cd birdhouse
-./pavics-compose.sh down
+birdhouse compose down
 ```
 
 Update the source code to the latest version using git:
@@ -51,14 +50,14 @@ Now perform any of the manual actions that you noted in a previous step. This wi
 Now start the stack up again:
 
 ```shell
-./pavics-compose.sh up --detach
+birdhouse compose up --detach
 ```
 
 Navigate to your node's URL in a browser and ensure that everything is running as expected.
 
 ```{warning}
-You must stop and restart the Marble software for the changes to take affect. This means that your Marble node will 
-be offline for up to several minutes. 
+You must stop and restart the Marble software for the changes to take affect. This means that your Marble node will
+be offline for up to several minutes.
 
 To avoid disruption to your users as much as possible we recommend warning your users before performing this update.
 Or at the very least, do the update at off-peak times when you expect minimal usage of the software.

--- a/tutorials/admin/monitoring/monitoring.md
+++ b/tutorials/admin/monitoring/monitoring.md
@@ -3,7 +3,7 @@
 Marble is deployed using the [Birdhouse](https://github.com/bird-house/birdhouse-deploy) software. This software
 includes some useful tools to monitor the usage and logs of your Marble node.
 
-These tools help you check inspect how your node is being used and can help you understand how to better allocate 
+These tools help you check inspect how your node is being used and can help you understand how to better allocate
 resources to ensure that your users get the best experience possible from your node.
 
 (grafana)=
@@ -15,7 +15,7 @@ the docker containers running on it to provide you an overview of how each is be
 [Grafana](https://grafana.com/grafana/dashboards/) is a visualization dashboard that takes the information collected by
 [Prometheus](https://prometheus.io/) and presents it to you in a visually useful manner.
 
-These monitoring tools can also send you email alerts when certain thresholds are reached. The threshold checks are 
+These monitoring tools can also send you email alerts when certain thresholds are reached. The threshold checks are
 pre-defined and include, for example:
 
 - the server is running low on memory, inodes, disk space, etc.
@@ -29,7 +29,7 @@ this [monitoring component](https://birdhouse-deploy.readthedocs.io/en/latest/bi
 
 ### Inspecting the Dashboard
 
-To inspect the Grafana dashboard, first log in as an administrator user and then navigate to 
+To inspect the Grafana dashboard, first log in as an administrator user and then navigate to
 `https://yournodeshostname.com/grafana` (replace `yournodehostname.com` with the actual hostname of your node).
 
 You will be asked to log in to the Grafana service itself. Use the password that you set when you set up the monitoring
@@ -49,7 +49,7 @@ component is behaving as expected. Also, if you ever need to submit a bug report
 the log output to help determine the cause of the bug.
 
 Marble uses [docker](https://www.docker.com/) underlyingly to deploy the various components in the stack. Docker keeps
-a log for each of the containers deployed in the stack. 
+a log for each of the containers deployed in the stack.
 
 To inspect the logs, we first need to figure out which container's logs we want to inspect.
 
@@ -60,11 +60,11 @@ your server and go to the `birdhouse/` subdirectory:
 cd birdhouse-deploy/birdhouse
 ```
 
-Then run the `pavics-compose.sh` script with the `ps` subcommand. This will show all running containers in the stack in
+Then run `birdhouse compose` with the `ps` subcommand. This will show all running containers in the stack in
 a table format.
 
 ```shell
-./pavics-compose.sh ps
+birdhouse compose ps
 ```
 
 Select which container you want to inspect and take note of the value in the "Name" column in the table.
@@ -77,7 +77,7 @@ docker logs proxy
 ```
 
 If you're not sure which container to inspect, the container names should be the same as the component names as
-described in the 
+described in the
 [Birdhouse documentation](https://birdhouse-deploy.readthedocs.io/en/latest/birdhouse/components/README.html#).
 
 ## Provide a public status page with Canarie-API
@@ -86,7 +86,7 @@ Canarie-API provides a simple view of the status of various components of your M
 to allow users to easily check whether services are working as intended without making sensitive information about your
 node public.
 
-See the [documentation](https://birdhouse-deploy.readthedocs.io/en/latest/birdhouse/components/README.html#canarie-api) 
+See the [documentation](https://birdhouse-deploy.readthedocs.io/en/latest/birdhouse/components/README.html#canarie-api)
 on how to enable the Canarie-API component for details.
 
 ```{warning}

--- a/tutorials/admin/services/services.md
+++ b/tutorials/admin/services/services.md
@@ -1,7 +1,7 @@
 # Services
 
-The Marble software can be configured to provide a variety of services to the users of your node. Services are 
-user-facing tools and the Birdhouse stack comes with several optional services that largely fall under the following 
+The Marble software can be configured to provide a variety of services to the users of your node. Services are
+user-facing tools and the Birdhouse stack comes with several optional services that largely fall under the following
 categories:
 
 - serving and cataloging data hosted on your server
@@ -12,8 +12,8 @@ categories:
 ## Enable an included service
 
 The Marble software comes with several services already included. The list of services already included can be found
-in the 
-[Birdhouse documentation](https://birdhouse-deploy.readthedocs.io/en/latest/birdhouse/components/README.html). This 
+in the
+[Birdhouse documentation](https://birdhouse-deploy.readthedocs.io/en/latest/birdhouse/components/README.html). This
 documentation explains what each service is used for and how to enable and configure it.
 
 You can pick and choose which services you would like to offer your users by enabling them via the `env.local` file.
@@ -22,17 +22,17 @@ In general, the process to enable a service is a follows:
 
 1. Take note of the directory that contains the service's code. In general this will be one of the directories in the
    `birdhouse/components` folder.
-2. Edit the `EXTRA_CONF_DIRS` variable in the `env.local` file to include the service's directory. This is a relative 
+2. Edit the `BIRDHOUSE_EXTRA_CONF_DIRS` variable in the `env.local` file to include the service's directory. This is a relative
    path from the `birdhouse/` directory *or* an absolute path. For example, to enable the Thredds service add the
-   string `./components/thredds` to the `EXTRA_CONF_DIRS` variable.
-3. Add or update any additional variables in `env.local` as required by the specific service (see the 
+   string `./components/thredds` to the `BIRDHOUSE_EXTRA_CONF_DIRS` variable.
+3. Add or update any additional variables in `env.local` as required by the specific service (see the
    [Birdhouse documentation](https://birdhouse-deploy.readthedocs.io/en/latest/birdhouse/components/README.html)
    for customization options for each service).
 4. Restart the software by running:
 
    ```shell
-   ./pavics-compose.sh down
-   ./pavice-compose.sh up -d
+   birdhouse compose down
+   birdhouse compose up -d
    ```
 
    in order for the changes to take effect.
@@ -46,15 +46,15 @@ Note that the [STAC catalog service](../../users/catalog/catalog.md) is always e
 ### Service customizations
 
 The Marble software also includes some useful service customizations. These are commonly used overrides that configure
-the default services in different ways. Details can be found in the 
+the default services in different ways. Details can be found in the
 [Birdhouse documentation](https://birdhouse-deploy.readthedocs.io/en/latest/birdhouse/optional-components/README.html).
 
 To enable any of these customizations, follow the same steps as [enabling a service](enable). Make sure that the
-customization is added to the `EXTRA_CONF_DIRS` variable **after** the service that it meant to customize. This is to 
+customization is added to the `BIRDHOUSE_EXTRA_CONF_DIRS` variable **after** the service that it meant to customize. This is to
 ensure that any changes to the settings in the customization are applied after the default settings.
 
 ```{warning}
-Some of the service customizations described in 
+Some of the service customizations described in
 [Birdhouse documentation](https://birdhouse-deploy.readthedocs.io/en/latest/birdhouse/optional-components/README.html)
 are meant for testing purposes only and are **not** meant to be deployed on a production server. Please read the
 description carefully before enabling any of these customizations.
@@ -62,7 +62,7 @@ description carefully before enabling any of these customizations.
 
 ## Enable an external service
 
-You are not restricted to only using the services that are provided by the 
+You are not restricted to only using the services that are provided by the
 [Birdhouse software](https://birdhouse-deploy.readthedocs.io/en/latest/birdhouse/components/README.html).
 The Marble software is extendable, and we encourage you to create, share, and deploy custom services as needed for your
 specific use cases.
@@ -70,7 +70,7 @@ specific use cases.
 To enable an external service, first download or create the service files in a folder outside the `birdhouse-deploy`
 repository. Then enable the service [as described above](enable) with the following minor changes:
 
-- ensure that the path added to `EXTRA_CONF_DIRS` in `env.local` is an *absolute* path. Relative paths from the
+- ensure that the path added to `BIRDHOUSE_EXTRA_CONF_DIRS` in `env.local` is an *absolute* path. Relative paths from the
   `birdhouse` directory will not work for external services.
-- carefully read any additional documentation that comes with the external component to ensure that you take any 
+- carefully read any additional documentation that comes with the external component to ensure that you take any
   additional configuration steps as well.

--- a/tutorials/admin/troubleshooting/faq.md
+++ b/tutorials/admin/troubleshooting/faq.md
@@ -7,9 +7,9 @@
 ### I cannot run docker as a non-root user
 
 Docker requires root permissions to run. If you do not want to manage Marble as the root user then you can configure
-Docker to permit access to users in the `docker` group. 
+Docker to permit access to users in the `docker` group.
 
-To set this up, see the instructions here: 
+To set this up, see the instructions here:
 https://docs.docker.com/engine/install/linux-postinstall/#manage-docker-as-a-non-root-user
 
 ### The webpage says my SSL certificate has expired, what do I do?
@@ -17,11 +17,12 @@ https://docs.docker.com/engine/install/linux-postinstall/#manage-docker-as-a-non
 Before you do anything else, you should update your SSL certificate.
 
 If your SSL certificate is provided to you by your domain name service or through a cloud provider, check their
-documentation on how to update your certificate. 
+documentation on how to update your certificate.
 
-If you got your SSL certificate through a service like [Let's Encrypt](https://letsencrypt.org/) then you can use a tool like 
+If you got your SSL certificate through a service like [Let's Encrypt](https://letsencrypt.org/) then you can use a tool like
 [certbot](https://certbot.eff.org/) to update it.
 
-Once your certificate has been updated, make sure that you've created a file that combines the 
-`privkey.pem` and `fullchain.pem` files and ensure that that file is set as the value of the `SSL_CERTIFICATE` variable
-in the `env.local` file. See the [installation example](example-installation-steps) for an example of this step.
+Once your certificate has been updated, make sure that you've created a file that combines the
+`privkey.pem` and `fullchain.pem` files and ensure that that file is set as the value of the
+`BIRDHOUSE_SSL_CERTIFICATE` variable in the `env.local` file. See the [installation example](example-installation-steps)
+for an example of this step.


### PR DESCRIPTION
As of [birdhouse-deploy version 2.4](https://github.com/bird-house/birdhouse-deploy/releases/tag/2.4.0) there are some changes to the command line interface and various variable names when deploying the stack.

This PR reflects these changes in the various admin tutorials that require direct access with the birdhouse stack.

It also looks like my editor trimmed whitespace from the end of a bunch of lines automatically. I'm inclined to leave it as is since these are good changes. But I apologize to reviewers... just ignore all changes that simply remove whitespace at the end of lines.